### PR TITLE
Update neobundle functions

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -7,9 +7,11 @@ if has('vim_starting')
   set runtimepath+=~/.vim/bundle/neobundle.vim/
 endif
 
-call neobundle#rc(expand('~/.vim/bundle/'))
+call neobundle#begin(expand('~/.vim/bundle/'))
 
 NeoBundleFetch 'Shougo/neobundle.vim'
+
+call neobundle#end()
 "}}}
 
 " Run and manage child processes, dependency of many other plugins "{{{


### PR DESCRIPTION
I was getting this error:

```
[neobundle] neobundle#rc() is deprecated function.
[neobundle] It will be removed in the next version.
[neobundle] Please use neobundle#begin()/neobundle#end() instead.
```

With those changes, it fixed the vim configuration and the error went away.
