### PR TITLE
Update install-script.sh: Changing source url of neobundle.vim

### DIFF
--- a/install-script.sh
+++ b/install-script.sh
@@ -5,7 +5,7 @@ curl https://raw.githubusercontent.com/Slava/vimrc/master/.vimrc > ~/.vimrc
 
 # Install the bundler
 mkdir -p ~/.vim/bundle
-git clone https://githubusercontent.com/Shougo/neobundle.vim ~/.vim/bundle/neobundle.vim
+git clone https://github.com/Shougo/neobundle.vim ~/.vim/bundle/neobundle.vim
 
 # Install all bundles
 vim -c "NeoBundleInstall" -c "q"


### PR DESCRIPTION
URL(https://githubusercontent.com/Shougo/neobundle.vim) is giving page 404 error. So changing it to URL given in manual installation.